### PR TITLE
Sending users to admin dashboard on settings update form submit

### DIFF
--- a/dbsettings/views.py
+++ b/dbsettings/views.py
@@ -8,6 +8,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.utils.text import capfirst
 from django.utils.translation import ugettext_lazy as _
 from django.contrib import messages
+from django.core.urlresolvers import reverse_lazy
 
 from dbsettings import loading, forms
 
@@ -54,7 +55,8 @@ def app_settings(request, app_label, template='dbsettings/app_settings.html'):
                                    'location': location})
                     messages.add_message(request, messages.INFO, update_msg)
 
-            return HttpResponseRedirect(request.path)
+            # Problem with settings not updated in form fields on save causing user errors. Sending to admin dash instead
+            return HttpResponseRedirect(reverse_lazy('admin:index'))
     else:
         # Leave the form populated with current setting values
         form = editor()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 # Dynamically calculate the version based on dbsettings.VERSION
-version_tuple = (0, 7, 2)
+version_tuple = (0, 7, 3)
 if version_tuple[2] is not None:
     if type(version_tuple[2]) == int:
         version = "%d.%d.%s" % version_tuple


### PR DESCRIPTION
Settings were not updating in the form on submit for some reason and admin users were taking actions like page refresh or re-submit which was saving a duplicate value and throwing a 500. Attempting to prevent this by sending them to the admin dashboard on form submit rather than back to the edit page.
