### PR TITLE
Handle Errors On Duplicate Key

### DIFF
--- a/dbsettings/loading.py
+++ b/dbsettings/loading.py
@@ -36,6 +36,15 @@ def get_setting_storage(module_name, class_name, attribute_name):
                 class_name=class_name,
                 attribute_name=attribute_name,
             )
+        except Setting.MultipleObjectsReturned :
+            from django.core.mail import mail_admins
+            error_msg = "A duplicate DBSettings key was found for module %s , class %s , attribute %s " % (module_name, class_name, attribute_name)
+            mail_admins("DBSettings Error - Duplicate Keys Found", error_msg)
+            storage = Setting.objects.filter(
+                module_name=module_name,
+                class_name=class_name,
+                attribute_name=attribute_name,
+            ).first()
         except Setting.DoesNotExist:
             setting_object = get_setting(module_name, class_name, attribute_name)
             storage = Setting(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 # Dynamically calculate the version based on dbsettings.VERSION
-version_tuple = (0, 7, 3)
+version_tuple = (0, 7, 4)
 if version_tuple[2] is not None:
     if type(version_tuple[2]) == int:
         version = "%d.%d.%s" % version_tuple


### PR DESCRIPTION
This bugfix patch will handle duplicate DB key errors gracefully, with a silent failure and an email to admins.

Encountering problems in production without a cache backend. Admin users were encountering problems with updates not saving (likely due to django cache) and DB Settings was saving a duplicate entry for some settings, in a scenario I can't pinpoint. This would cause a 500 error on the admin page, and also return None in templates.

Solved by handling the duplicate error, sending an alert email and replacing the queryset .get() with .first()
